### PR TITLE
Update grep_lookahead_lookbehind.sh

### DIFF
--- a/bash/grep_lookahead_lookbehind.sh
+++ b/bash/grep_lookahead_lookbehind.sh
@@ -36,7 +36,7 @@ grep -Po "(?<=https://)([^ /?\"])*" $testfile
 
 echo ""
 echo "#############################"
-echo "PCR Perl regex with brute forced variable length LookBehind, use /K instead"
+echo "PCR Perl regex with brute forced variable length LookBehind, use \K instead"
 grep -Po "(?:(?<=http://)|(?<=https://))([^ /?\"])*" $testfile
 
 echo ""


### PR DESCRIPTION
Your accompanying [blog post](https://fabianlee.org/2021/01/09/bash-grep-with-lookbehind-and-lookahead-to-isolate-desired-text/) also mentions `/K` a few times where it should be `\K`.